### PR TITLE
key action supporting multiple keys and special characters

### DIFF
--- a/src/naga.cpp
+++ b/src/naga.cpp
@@ -1,19 +1,20 @@
 /* See https://github.com/RaulPPelaez/Naga_KeypadMapper/graphs/contributors
-* for a full list of contributors.
-* This program is free software. It comes without any warranty, to the extent
-* permitted by applicable law. You can redistribute it and/or modify it under the
-* terms of the Beer-ware license revision 42.
-* ----------------------------------------------------------------------------
-* "THE BEER-WARE LICENSE" (Revision 42):
-* RaulPPelaez, et. al wrote this file.  As long as you retain this notice you
-* can do whatever you want with this stuff. If we meet some day, and you think
-* this stuff is worth it, you can buy me a beer in return. RaulPPelaez 2016
-* ----------------------------------------------------------------------------
-*/
+ * for a full list of contributors.
+ * This program is free software. It comes without any warranty, to the extent
+ * permitted by applicable law. You can redistribute it and/or modify it under the
+ * terms of the Beer-ware license revision 42.
+ * ----------------------------------------------------------------------------
+ * "THE BEER-WARE LICENSE" (Revision 42):
+ * RaulPPelaez, et. al wrote this file.  As long as you retain this notice you
+ * can do whatever you want with this stuff. If we meet some day, and you think
+ * this stuff is worth it, you can buy me a beer in return. RaulPPelaez 2016
+ * ----------------------------------------------------------------------------
+ */
 #include <cstdio>
 #include <iostream>
 #include <string>
 #include <vector>
+#include <sstream>
 #include <algorithm>
 #include <fstream>
 #include <fcntl.h>
@@ -22,6 +23,7 @@
 #include <linux/input.h>
 #include <sys/select.h>
 #include <cstring>
+#include <iostream>
 #define DEV_NUM_KEYS 12
 #define EXTRA_BUTTONS 2
 #define OFFSET 263
@@ -44,28 +46,28 @@ class NagaDaemon {
 public:
   NagaDaemon(int argc, char *argv[]) {
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Epic-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Epic-event-mouse");              // NAGA EPIC
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Epic-event-mouse");              // NAGA EPIC
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Dock-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Dock-event-mouse");         // NAGA EPIC DOCK
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Dock-event-mouse");         // NAGA EPIC DOCK
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_2014-if02-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_2014-event-mouse");              // NAGA 2014
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_2014-event-mouse");              // NAGA 2014
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga-event-mouse");                   // NAGA MOLTEN
+                         "/dev/input/by-id/usb-Razer_Razer_Naga-event-mouse");                   // NAGA MOLTEN
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-event-mouse");       // NAGA EPIC CHROMA
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma-event-mouse");       // NAGA EPIC CHROMA
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma_Dock-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma_Dock-event-mouse");  // NAGA EPIC CHROMA DOCK
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Epic_Chroma_Dock-event-mouse");  // NAGA EPIC CHROMA DOCK
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Chroma-if02-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Chroma-event-mouse");            // NAGA CHROMA
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Chroma-event-mouse");            // NAGA CHROMA
     devices.emplace_back("/dev/input/by-id/usb-Razer_Razer_Naga_Hex-if01-event-kbd",
-			 "/dev/input/by-id/usb-Razer_Razer_Naga_Hex-event-mouse");               // NAGA HEX
+                         "/dev/input/by-id/usb-Razer_Razer_Naga_Hex-event-mouse");               // NAGA HEX
         
     size = sizeof(struct input_event);
     //Setup check
     for (auto &device : devices) {
       if ((side_btn_fd = open(device.first, O_RDONLY)) != -1 &&  (extra_btn_fd = open(device.second, O_RDONLY)) != -1) {
-	cout << "Reading from: " << device.first << " and " << device.second << endl;
-	break;
+        cout << "Reading from: " << device.first << " and " << device.second << endl;
+        break;
       }
     }
     if (side_btn_fd == -1 || extra_btn_fd == -1) {
@@ -103,25 +105,25 @@ public:
       //Lines starting with "#" are ignored
 
       //Thanks @lostallmymoney for fixing these lines!
-	//divide at =
-	pos = line.find('=');
-	line1 = line.substr(0, pos); //line1 = numbers and stull
+      //divide at =
+      pos = line.find('=');
+      line1 = line.substr(0, pos); //line1 = numbers and stull
 	
-	//Erase spaces before the =
-	line.erase(0, pos+1); //line = command
-	//Erase spaces before the =
-	line1.erase(std::remove(line1.begin(), line1.end(), ' '), line1.end());
-	//Ignore comments
-	if (line1[0] == '#') 
-	  continue;
+      //Erase spaces before the =
+      line.erase(0, pos+1); //line = command
+      //Erase spaces before the =
+      line1.erase(std::remove(line1.begin(), line1.end(), ' '), line1.end());
+      //Ignore comments
+      if (line1[0] == '#') 
+        continue;
 
-	//Search option and argument
-	pos = line1.find("-");
-	token1 = line1.substr(0, pos);
-	line1 = line1.substr(pos + 1);
+      //Search option and argument
+      pos = line1.find("-");
+      token1 = line1.substr(0, pos);
+      line1 = line1.substr(pos + 1);
 
-	//Encode and store mapping
-	pos = stoi(token1) - 1;
+      //Encode and store mapping
+      pos = stoi(token1) - 1;
       if (line1 == "chmap") options[pos].push_back(Operators::chmap);
       else if (line1 == "key") options[pos].push_back(Operators::key);
       else if (line1 == "run") options[pos].push_back(Operators::run);
@@ -130,15 +132,15 @@ public:
       else if (line1 == "workspace_r") options[pos].push_back(Operators::workspace_r);
       else if (line1 == "workspace") options[pos].push_back(Operators::workspace);
       else if (line1 == "position") {
-	options[pos].push_back(Operators::position);
-	std::replace(line.begin(), line.end(), ',', ' ');
+        options[pos].push_back(Operators::position);
+        std::replace(line.begin(), line.end(), ',', ' ');
       }
       else if (line1 == "delay") options[pos].push_back(Operators::delay);
       else if (line1 == "media") options[pos].push_back(Operators::media);
       else if (line1 == "toggle") options[pos].push_back(Operators::toggle);
       else {
-	cerr << "Not supported key action, check the syntax in " << conf_file << ". Exiting!" << endl;
-	exit(1);
+        cerr << "Not supported key action, check the syntax in " << conf_file << ". Exiting!" << endl;
+        exit(1);
       }
       //cerr << "b) len: " << len << " pos: " << pos << " line: " << line << " args[pos] size:" << args[pos].size() << "\n";
       clog<<"Line : "<<line<<endl;
@@ -163,46 +165,52 @@ public:
       if (rd == -1) exit(2);
 
       if (FD_ISSET(side_btn_fd, &readset)) // Side buttons
-	{
-	  rd1 = read(side_btn_fd, ev1, size * 64);
-	  if (rd1 == -1) exit(2);
+        {
+          rd1 = read(side_btn_fd, ev1, size * 64);
+          if (rd1 == -1) exit(2);
 
-	  if (ev1[0].value != ' ' && ev1[1].type == EV_KEY)  //Key event (press or release)
-	    switch (ev1[1].code) {
-	    case 2:
-	    case 3:
-	    case 4:
-	    case 5:
-	    case 6:
-	    case 7:
-	    case 8:
-	    case 9:
-	    case 10:
-	    case 11:
-	    case 12:
-	    case 13:
-	      chooseAction(ev1[1].code - 2, ev1[1].value); //ev1[1].value holds 1 if press event and 0 if release
-	      break;
-	      // do nothing on default
-	    }
+          if (ev1[0].value != ' ' && ev1[1].type == EV_KEY)  //Key event (press or release)
+            switch (ev1[1].code) {
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+            case 9:
+            case 10:
+            case 11:
+            case 12:
+            case 13:
+              chooseAction(ev1[1].code - 2, ev1[1].value); //ev1[1].value holds 1 if press event and 0 if release
+              break;
+              // do nothing on default
+            }
 
-	}
+        }
       else // Extra buttons
-	{
-	  rd2 = read(extra_btn_fd, ev2, size * 64);
-	  if (rd2 == -1) exit(2);
+        {
+          rd2 = read(extra_btn_fd, ev2, size * 64);
+          if (rd2 == -1) exit(2);
 
-	  if (ev2[1].type == 1 && ev2[1].value == 1) //Only extra buttons
-	    switch (ev2[1].code) {
-	    case 275:
-	    case 276:
-	      chooseAction(ev2[1].code - OFFSET, 1);
-	      break;
-	      // do nothing on default
-	    }
+          if (ev2[1].type == 1 && ev2[1].value == 1) //Only extra buttons
+            switch (ev2[1].code) {
+            case 275:
+            case 276:
+              chooseAction(ev2[1].code - OFFSET, 1);
+              break;
+              // do nothing on default
+            }
 
-	}
+        }
     }
+  }
+
+  void executeAction(bool execution, string command){
+    int pid;
+    if (execution)
+      pid = system(command.c_str());
   }
 
   void chooseAction(int i, int eventCode /*1 for press, 0 for release*/) {
@@ -224,13 +232,24 @@ public:
       execution = true;
       switch (options[i][j]) {
       case Operators::chmap: //switch mapping
-	this->loadConf(args[i][j]);
-	execution = false;
-	break;
+        this->loadConf(args[i][j]);
+        execution = false;
+        break;
       case Operators::key: //key press/release
-	if(eventCode==1)           command = keydownop + args[i][j];
-	else if(eventCode==0)      command = keyupop + args[i][j];
-	break;
+        if(eventCode==1){
+          string arguments = args[i][j];
+          //clog << arguments << endl;
+          for (int k=0; k<arguments.length(); k++ ){
+            stringstream output;
+            output << "0x00" << std::hex << (int)arguments[k];
+            //clog << output.str() << endl;
+            command = keydownop + output.str();
+            executeAction(execution, command);
+            command = keyupop + output.str();
+            executeAction(execution, command);
+          }
+        } else if(eventCode==0){execution = false;}
+        return;
       case Operators::run:         command = "setsid " + args[i][j] + " &";if(eventCode==0) execution=false; break;
       case Operators::run2:        command = "setsid " + args[i][j] + " &"; break;
       case Operators::click:       command = clickop + args[i][j];         if(eventCode==0) execution=false; break;
@@ -239,30 +258,30 @@ public:
       case Operators::position:    command = position + args[i][j];        if(eventCode==0) execution=false; break;
       case Operators::media:       command = "xdotool key XF86" + args[i][j] + " "; if(eventCode==0) execution=false; break;
       case Operators::delay: //delay execution n milliseconds
-	delay = stoi(args[i][j]) * 1000;
-	usleep(delay);
-	execution = false;
-	break;
+        delay = stoi(args[i][j]) * 1000;
+        usleep(delay);
+        execution = false;
+        break;
       case Operators::toggle: // Toggle action
-	if(eventCode==0){
-	  execution=false;
-	}
-	else{	
-	  if (state[i][j] == 0) {
-	    command = keydownop + args[i][j];
-	    state[i][j] = 1;
-	  }
-	  else if (state[i][j] == 1) {
-	    command = keyupop + args[i][j];
-	    state[i][j] = 0;
-	  }
-	}
-	break;
+        if(eventCode==0){
+          execution=false;
+        }
+        else{	
+          if (state[i][j] == 0) {
+            command = keydownop + args[i][j];
+            state[i][j] = 1;
+          }
+          else if (state[i][j] == 1) {
+            command = keyupop + args[i][j];
+            state[i][j] = 0;
+          }
+        }
+        break;
       }
-
+      
       
       if (execution)
-	pid = system(command.c_str());
+        pid = system(command.c_str());
     }
   }
 };


### PR DESCRIPTION
Now the action key supports multiple characters and also special ones like /<'">.

And example for a mapping file would be something like this:

`2 - key=\'>\">'>"><perrito/()><"<'<\"<\`

this will simulate the keys:

`\'>\">'>"><perrito/()><"<'<\"<\`

Sorry for the white space changes, emacs just did it. :)
